### PR TITLE
Add AUR instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,14 @@ A Linux based OS.
 
 You can download the pre-built binaries from the release page [release page](https://github.com/pythops/oryx/releases)
 
+### 🐧Arch Linux
+
+You can install `oryx` from the [AUR](https://aur.archlinux.org/packages/oryx) with using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers).
+
+```bash
+paru -S oryx
+```
+
 ### ⚒️ Build from source
 
 To build `oryx`:


### PR DESCRIPTION
- https://aur.archlinux.org/packages/oryx

It is unfortunately not being built via `--release` due to:

```
error: couldn't read `oryx-tui/src/../../target/bpfel-unknown-none/debug/oryx`: No such file or directory (os error 2)
  --> oryx-tui/src/ebpf.rs:75:41
   |
75 |                   let mut bpf = Bpf::load(include_bytes_aligned!(
   |  _________________________________________^
76 | |                     "../../target/bpfel-unknown-none/debug/oryx"
77 | |                 ))
   | |_________________^
   |
   = note: this error originates in the macro `include_bytes` which comes from the expansion of the macro `include_bytes_aligned` (in Nightly builds, run with -Z macro-backtrace for more info)

error: couldn't read `oryx-tui/src/../../target/bpfel-unknown-none/debug/oryx`: No such file or directory (os error 2)
   --> oryx-tui/src/ebpf.rs:152:41
    |
152 |                   let mut bpf = Bpf::load(include_bytes_aligned!(
    |  _________________________________________^
153 | |                     "../../target/bpfel-unknown-none/debug/oryx"
154 | |                 ))
    | |_________________^
    |
    = note: this error originates in the macro `include_bytes` which comes from the expansion of the macro `include_bytes_aligned` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Will look into it later. For more context, see: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=oryx
