### PR TITLE
Fix/hardcode paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,11 @@ jobs:
         run: cargo xtask build-ebpf
 
       - name: Build oryx-tui
-        run: cargo build
+        run: cargo xtask build
 
       - name: Linting
         run: |
-          cargo clippy --workspace --all-features -- -D warnings
+          cargo xtask lint
           cargo fmt --all -- --check
           cd oryx-ebpf
           cargo clippy --workspace --all-features -- -D warnings

--- a/oryx-tui/src/ebpf/egress.rs
+++ b/oryx-tui/src/ebpf/egress.rs
@@ -54,9 +54,8 @@ pub fn load_egress(
             #[cfg(debug_assertions)]
             let mut bpf = match EbpfLoader::new()
                 .set_global("TRAFFIC_DIRECTION", &traffic_direction, true)
-                .load(include_bytes_aligned!(
-                    "../../../target/bpfel-unknown-none/debug/oryx"
-                )) {
+                .load(include_bytes_aligned!(env!("ORYX_BIN_PATH")))
+            {
                 Ok(v) => v,
                 Err(e) => {
                     error!("Fail to load the egress eBPF bytecode. {}", e);
@@ -73,9 +72,8 @@ pub fn load_egress(
             #[cfg(not(debug_assertions))]
             let mut bpf = match EbpfLoader::new()
                 .set_global("TRAFFIC_DIRECTION", &traffic_direction, true)
-                .load(include_bytes_aligned!(
-                    "../../../target/bpfel-unknown-none/debug/oryx"
-                )) {
+                .load(include_bytes_aligned!(env!("ORYX_BIN_PATH")))
+            {
                 Ok(v) => v,
                 Err(e) => {
                     error!("Fail to load the egress eBPF bytecode. {}", e);

--- a/oryx-tui/src/ebpf/ingress.rs
+++ b/oryx-tui/src/ebpf/ingress.rs
@@ -54,9 +54,8 @@ pub fn load_ingress(
             #[cfg(debug_assertions)]
             let mut bpf = match EbpfLoader::new()
                 .set_global("TRAFFIC_DIRECTION", &traffic_direction, true)
-                .load(include_bytes_aligned!(
-                    "../../../target/bpfel-unknown-none/debug/oryx"
-                )) {
+                .load(include_bytes_aligned!(env!("ORYX_BIN_PATH")))
+            {
                 Ok(v) => v,
                 Err(e) => {
                     error!("Failed to load the ingress eBPF bytecode. {}", e);
@@ -73,9 +72,8 @@ pub fn load_ingress(
             #[cfg(not(debug_assertions))]
             let mut bpf = match EbpfLoader::new()
                 .set_global("TRAFFIC_DIRECTION", &traffic_direction, true)
-                .load(include_bytes_aligned!(
-                    "../../../target/bpfel-unknown-none/debug/oryx"
-                )) {
+                .load(include_bytes_aligned!(env!("ORYX_BIN_PATH")))
+            {
                 Ok(v) => v,
                 Err(e) => {
                     error!("Failed to load the ingress eBPF bytecode. {}", e);

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -52,3 +52,23 @@ pub fn build(opts: Options) -> Result<(), anyhow::Error> {
     build_project(&opts).context("Error while building userspace application")?;
     Ok(())
 }
+
+
+/// Run linter on the project with ORYX_BIN_DIR env var set
+pub fn lint() -> Result<(), anyhow::Error> {
+    set_ebpf_build_base_dir("debug");
+    let status = Command::new("cargo")
+        .args([
+            "clippy",
+            "--workspace",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ])
+        .status()
+        .expect("failed to build userspace");
+
+    assert!(status.success());
+    Ok(())
+}

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -18,7 +18,7 @@ pub struct Options {
 /// Set the ORYX_BIN_PATH env var based on build option
 fn set_ebpf_build_base_dir(build_type: &str) {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join(format!("../target/bpfel-unknown-none/{}/oryx", build_type))
+        .join(format!("../target/bpfel-unknown-none/{build_type}/oryx"))
         .to_path_buf();
     std::env::set_var("ORYX_BIN_PATH", &path);
 }

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{path::Path, process::Command};
 
 use anyhow::Context as _;
 use clap::Parser;
@@ -15,12 +15,24 @@ pub struct Options {
     pub release: bool,
 }
 
+/// Set the ORYX_BIN_PATH env var based on build option
+fn set_ebpf_build_base_dir(build_type: &str) {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(format!("../target/bpfel-unknown-none/{}/oryx", build_type))
+        .to_path_buf();
+    std::env::set_var("ORYX_BIN_PATH", &path);
+}
+
 /// Build the project
 fn build_project(opts: &Options) -> Result<(), anyhow::Error> {
     let mut args = vec!["build"];
     if opts.release {
-        args.push("--release")
+        args.push("--release");
+        set_ebpf_build_base_dir("release");
+    } else {
+        set_ebpf_build_base_dir("debug");
     }
+
     let status = Command::new("cargo")
         .args(&args)
         .status()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ enum Command {
     BuildEbpf(build_ebpf::Options),
     Run(run::Options),
     Build(build::Options),
+    Lint,
 }
 
 fn main() {
@@ -27,6 +28,7 @@ fn main() {
         BuildEbpf(opts) => build_ebpf::build_ebpf(opts),
         Run(opts) => run::run(opts),
         Build(opts) => build::build(opts),
+        Lint => build::lint(),
     };
 
     if let Err(e) = ret {


### PR DESCRIPTION
Possibly related to https://github.com/pythops/oryx/pull/5, I noticed that trying to build with the release flag on a freshly cloned repo fails, because the build path when loading ebpf programs is hard coded and assumes a debug build. This PR adds a simple fix to avoid hard coding paths by using an environment variable, set within the xtask build function, to define the path based on whether the release flag is passed or not. There is also a commit that modifies CI script to accommodate the fix