### PR TITLE
Fixes IPv4 hostname retrieval

### DIFF
--- a/oryx-tui/src/dns.rs
+++ b/oryx-tui/src/dns.rs
@@ -17,7 +17,7 @@ fn get_hostname_v4(ip: &Ipv4Addr) -> AppResult<String> {
         sin_family: libc::AF_INET as u16,
         sin_port: 0,
         sin_addr: libc::in_addr {
-            s_addr: ip.to_bits(),
+            s_addr: u32::from_ne_bytes(ip.octets()),
         },
         sin_zero: [0; 8],
     };


### PR DESCRIPTION
Fixes issue with hostname retrieval used for IPv4 addresses in the "Stats" tab (due to the byte order; `to_bits()` converts to "representation using native byte order")

This can be seen with connecting to `172.217.0.165` (Google IP); current version shows lookup result for `165.0.217.172` rather than `1e100.net`, a Google domain (as seen in fixed version).
<img height="350" alt="original version" src="https://github.com/user-attachments/assets/2fbdc0ad-8e7a-4f42-a55f-9c4a5391871a" /> <img height="350" alt="fixed version" src="https://github.com/user-attachments/assets/cf5bc09a-49eb-4d47-886c-505a987692d1" />